### PR TITLE
adding pr templates and code owners

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,10 @@
+# Title
+
+One to two sentence description. Add current and expected behavior if the issue is a bug.
+
+## Type of Issue
+
+- [ ] New feature
+- [ ] Bug fix
+- [ ] Documentation update
+- [ ] Other

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+# Title
+
+One to two sentence description.
+
+- Main update 1
+- Main update 2
+- Main update 3
+
+## Type of Change
+
+- [ ] New feature
+- [ ] Bug fix
+- [ ] Breaking change
+- [ ] Documentation update
+
+## Screenshots/Screen Recordings
+
+Please attach screenshots or screen recordings if you made a UI change.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# default give essential owners
+* @core
+
+# specify other owners below!

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # default give essential owners
-* @core
+* @Give-Essential/core
 
 # specify other owners below!


### PR DESCRIPTION
# adding pr templates and code owners

Adding PR and Issue templates and `CODEOWNERS` file requiring review by @Give-Essential/core.

- added `.github`
- added `CODEOWNERS`